### PR TITLE
Adding the ability to configure event listener options

### DIFF
--- a/unipointer.js
+++ b/unipointer.js
@@ -67,7 +67,7 @@ proto._bindStartEvent = function( elem, isAdd ) {
     // Touch Events. iOS Safari
     startEvent = 'touchstart';
   }
-  elem[ bindMethod ]( startEvent, this );
+  elem[ bindMethod ]( startEvent, this, this.listenerOpts || false );
 };
 
 // trigger handler methods for events


### PR DESCRIPTION
Modern browsers have started making passive listeners `true` by default, so it'd be really helpful if Unidragger/Unipointer had a convenient way to specify event listener options, e.g. `{ passive: false }`. Setting passive to false is necessary to ensure the JS logic that these libraries are built around actually fire before scrolling occurs.

The pattern for extending options in this library seems to be prototypal, so my suggestion followed that line of thinking and would look something like this in practice:

```
// create new class
function PointerFun( elem ) {
  this.element = elem;
  this.listenerOpts = { passive: false };
  // binds mousedown/touchstart/pointerdown event
  this._bindStartEvent( this.element, true );
}
...
```